### PR TITLE
fix build error

### DIFF
--- a/fias.gemspec
+++ b/fias.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Write a short summary, because Rubygems requires one.}
   spec.description   = %q{Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "https://github.com/uchiru/fias"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'


### PR DESCRIPTION
Ошибка при сборке в шамане на новом bundler-e (1.16.1)
```
The gemspec at /usr/local/bundle/bundler/gems/fias-c0e41655222a/fias.gemspec is
not valid. Please fix this gemspec.
The validation error was '"TODO: Put your gem's website or public repo URL
here." is not a valid HTTP URI'
```